### PR TITLE
Fix oauth documentation link

### DIFF
--- a/_documentation/en/provisioning/code-snippets/account/get-account-by-id.md
+++ b/_documentation/en/provisioning/code-snippets/account/get-account-by-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/provisioning/code-snippets/account/get-account-location-by-account-id.md
+++ b/_documentation/en/provisioning/code-snippets/account/get-account-location-by-account-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/provisioning/code-snippets/account/get-location-data-account-id-location-id.md
+++ b/_documentation/en/provisioning/code-snippets/account/get-location-data-account-id-location-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | location_id       | The location Id. |
 


### PR DESCRIPTION
Change link to /getting-started/create-a-developer-account