### PR TITLE
Update Read More About OAuth Tokens link

### DIFF
--- a/_documentation/en/call-recording/code-snippets/company-call-recording/create-company-call–recording-export-job.md
+++ b/_documentation/en/call-recording/code-snippets/company-call-recording/create-company-call–recording-export-job.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | call_direction           | Filter recordings by call direction. Must be one of: `INBOUND` `OUTBOUND` or `INTRA_PBX` |
 

--- a/_documentation/en/call-recording/code-snippets/company-call-recording/delete-company-call-recording.md
+++ b/_documentation/en/call-recording/code-snippets/company-call-recording/delete-company-call-recording.md
@@ -10,7 +10,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | recording_id      | The recording ID. | 
 

--- a/_documentation/en/call-recording/code-snippets/company-call-recording/get-company-call-recordings.md
+++ b/_documentation/en/call-recording/code-snippets/company-call-recording/get-company-call-recordings.md
@@ -10,7 +10,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 
 ``` bash

--- a/_documentation/en/call-recording/code-snippets/company-call-recording/get-single-company-call-recording.md
+++ b/_documentation/en/call-recording/code-snippets/company-call-recording/get-single-company-call-recording.md
@@ -10,7 +10,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | recording_id      | The recording ID | 
 

--- a/_documentation/en/call-recording/code-snippets/download/download-export-job.md
+++ b/_documentation/en/call-recording/code-snippets/download/download-export-job.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | job_id 			| The job ID |
 | login_name        | The login_name of the user |
 

--- a/_documentation/en/call-recording/code-snippets/download/download-recording.md
+++ b/_documentation/en/call-recording/code-snippets/download/download-recording.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | recording_id      | The recording ID |
 

--- a/_documentation/en/call-recording/code-snippets/export-job/get-call-recording-export-job.md
+++ b/_documentation/en/call-recording/code-snippets/export-job/get-call-recording-export-job.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. |
 | job_id            | The job ID |

--- a/_documentation/en/call-recording/code-snippets/export-job/get-call-recording-export-jobs.md
+++ b/_documentation/en/call-recording/code-snippets/export-job/get-call-recording-export-jobs.md
@@ -13,7 +13,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. | 
 

--- a/_documentation/en/call-recording/code-snippets/on-demand-call-recording/create-on-demand-call-recording-export-job.md
+++ b/_documentation/en/call-recording/code-snippets/on-demand-call-recording/create-on-demand-call-recording-export-job.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. |
 | call_direction           | Filter recordings by call direction. Must be one of: `INBOUND`, `OUTBOUND` or `INTRA_PBX` |

--- a/_documentation/en/call-recording/code-snippets/on-demand-call-recording/delete-on-demand-call-recording.md
+++ b/_documentation/en/call-recording/code-snippets/on-demand-call-recording/delete-on-demand-call-recording.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. |
 | recording_id.     | The recording ID |

--- a/_documentation/en/call-recording/code-snippets/on-demand-call-recording/get-on-demand-call-recordings.md
+++ b/_documentation/en/call-recording/code-snippets/on-demand-call-recording/get-on-demand-call-recordings.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. |
 

--- a/_documentation/en/call-recording/code-snippets/on-demand-call-recording/get-single-on-demand-call-recording.md
+++ b/_documentation/en/call-recording/code-snippets/on-demand-call-recording/get-single-on-demand-call-recording.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 | user_id           | The Vonage Business Communications user ID. You can use 'self' to refer to the authenticated user. |
 | recording_id      | The recording ID |

--- a/_documentation/en/getting-started/make-an-api-request.md
+++ b/_documentation/en/getting-started/make-an-api-request.md
@@ -16,7 +16,7 @@ Replace the following placeholder values in the sample code:
 
 | Key        | Description                                                                                            |
 |------------|--------------------------------------------------------------------------------------------------------|
-| bearer_token | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id | The Vonage Business Communications account ID. You can use 'self' to refer to the authenticated user's account. |
 
 ``` bash

--- a/_documentation/en/provisioning/code-snippets/extension/get-account-extension-by-account-id.md
+++ b/_documentation/en/provisioning/code-snippets/extension/get-account-extension-by-account-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/provisioning/code-snippets/extension/get-extension-by-account-id-extension-number.md
+++ b/_documentation/en/provisioning/code-snippets/extension/get-extension-by-account-id-extension-number.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | external_id      | The extension ID. |
 

--- a/_documentation/en/provisioning/code-snippets/user/get-account-users-by-account-id.md
+++ b/_documentation/en/provisioning/code-snippets/user/get-account-users-by-account-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/provisioning/code-snippets/user/get-user-by-account-id-user-id.md
+++ b/_documentation/en/provisioning/code-snippets/user/get-user-by-account-id-user-id.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | user_id           | The Vonage Business Communications user ID. |
 

--- a/_documentation/en/reports/code-snippets/retrieve-call-logs-for-account.md
+++ b/_documentation/en/reports/code-snippets/retrieve-call-logs-for-account.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | start_gte         | Filter records by start date (greater equal or equal to). Must be in the following format YYYY-MM-DD HH:mm:ss | 
 | start_lte         | Filter records by start date (less equal or equal to).  Must be in the following format YYYY-MM-DD HH:mm:ss | 

--- a/_documentation/en/telephony/code-snippets/call/create-new-call.md
+++ b/_documentation/en/telephony/code-snippets/call/create-new-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | from_type         | The type of destination. Can be one of two values `extension` , or `device` |
 | from_destination  | The destination. If  `from_type` is `extension`, then the `from_destination` must be an extension. If `from_type` is `device`, then the `from_destination` must be a valid device ID. | 

--- a/_documentation/en/telephony/code-snippets/call/delete-call-resource.md
+++ b/_documentation/en/telephony/code-snippets/call/delete-call-resource.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call you would like to delete| 
 

--- a/_documentation/en/telephony/code-snippets/call/get-details-for-call.md
+++ b/_documentation/en/telephony/code-snippets/call/get-details-for-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id.          | The call ID for the call you would like to delete | 
 

--- a/_documentation/en/telephony/code-snippets/call/get-list-of-calls-for-a-given-account.md
+++ b/_documentation/en/telephony/code-snippets/call/get-list-of-calls-for-a-given-account.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/telephony/code-snippets/call/update-call.md
+++ b/_documentation/en/telephony/code-snippets/call/update-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call you would like to update. |
 | from_type         | The type of destination. Can be one of three values `extension` , `device`, or `pstn`. |

--- a/_documentation/en/telephony/code-snippets/call_leg/delete-call-leg.md
+++ b/_documentation/en/telephony/code-snippets/call_leg/delete-call-leg.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call |
 | leg_id            | The call leg id you want to remove |  

--- a/_documentation/en/telephony/code-snippets/call_leg/dtmf-existing-call.md
+++ b/_documentation/en/telephony/code-snippets/call_leg/dtmf-existing-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call you would like to update |
 | leg               | The leg id for the call you would like to update |

--- a/_documentation/en/telephony/code-snippets/call_leg/get-details-for-call-leg.md
+++ b/_documentation/en/telephony/code-snippets/call_leg/get-details-for-call-leg.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call  | 
 | leg_id            | The leg id for the call you would like to retrieve | 

--- a/_documentation/en/telephony/code-snippets/call_leg/get-list-legs-for-call.md
+++ b/_documentation/en/telephony/code-snippets/call_leg/get-list-legs-for-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | leg_id            | The leg id for the leg you would like to get | 
 

--- a/_documentation/en/telephony/code-snippets/call_leg/stream-audio-existing-call.md
+++ b/_documentation/en/telephony/code-snippets/call_leg/stream-audio-existing-call.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | call_id           | The call id for the call you would like to update |
 | leg               | The leg id for the call you would like to update |

--- a/_documentation/en/telephony/code-snippets/device_registration/get-account-device-registration.md
+++ b/_documentation/en/telephony/code-snippets/device_registration/get-account-device-registration.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 
 ``` bash

--- a/_documentation/en/telephony/code-snippets/device_registration/get-device-registration-info.md
+++ b/_documentation/en/telephony/code-snippets/device_registration/get-device-registration-info.md
@@ -11,7 +11,7 @@ Replace the following placeholder values in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | account_id        | The Vonage Business Communications account ID. |
 | device_id         | MAC address of device | 
 

--- a/_documentation/en/vonage-integration-platform/code-snippets/account/get-account-info.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/account/get-account-info.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/account' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/answer-a-call.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/answer-a-call.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/end-a-call.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/end-a-call.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/get-a-call.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/get-a-call.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/get-calls-count.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/get-calls-count.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/calls/count' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/list-active-calls.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/list-active-calls.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/calls' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/put-call-on-hold.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/put-call-on-hold.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/send-call-to-voicemail.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/send-call-to-voicemail.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/transfer-a-call.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/transfer-a-call.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 | phoneNumber       | Phone number to transfer to |
 

--- a/_documentation/en/vonage-integration-platform/code-snippets/call/unhold-a-call.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/call/unhold-a-call.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the call |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/event/get-an-event.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/event/get-an-event.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the event |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/event/get-events-count.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/event/get-events-count.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/events/count' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/event/list-events.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/event/list-events.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/events' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/user/get-user-info.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/user/get-user-info.md
@@ -11,7 +11,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/webhook/create-a-new-webhook.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/webhook/create-a-new-webhook.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | url               | Destination URL for events |
 | events            | Array of events to subscribe to |
 | signingAlgo       | Signing algorithm for the webhook |

--- a/_documentation/en/vonage-integration-platform/code-snippets/webhook/get-webhook-details.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/webhook/get-webhook-details.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the webhook |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/webhook/list-webhooks.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/webhook/list-webhooks.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 
 ``` bash
 curl --location --request GET 'https://api.vonage.com/t/vbc.prod/vis/v1/self/webhooks' \

--- a/_documentation/en/vonage-integration-platform/code-snippets/webhook/remove-a-webhook.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/webhook/remove-a-webhook.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the webhook |
 
 ``` bash

--- a/_documentation/en/vonage-integration-platform/code-snippets/webhook/renew-a-webhook.md
+++ b/_documentation/en/vonage-integration-platform/code-snippets/webhook/renew-a-webhook.md
@@ -10,7 +10,7 @@ Replace the following placeholder value in the sample code:
 
 | Key | Description |
 | --- | ----------- |
-| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/concepts/guides/create-an-access-token) |
+| bearer_token      | Your OAuth token. [Read more about OAuth tokens](/getting-started/create-a-developer-account) |
 | id                | Unique identifier of the webhook |
 
 ``` bash


### PR DESCRIPTION
Fix broken links + bring users to the beginning of getting started rather than directly to the token.  Since you can get to these pages out of context, we want to add more clarity about all the steps you need to take before you can get the token.