### PR TITLE
Fixed more special chars causing build fails

### DIFF
--- a/_documentation/en/open-contactpad/sdk-reference.md
+++ b/_documentation/en/open-contactpad/sdk-reference.md
@@ -74,7 +74,7 @@ load (see [Loading Open ContactPad SDK](loading-contactpad))
 
 | Parameters | Type | Description |
 | --- | ----- | ----------- |
-| provider | “cc" / “uc" | <ul><li>CC loads Vonage Call Center ContactPad as a dialer interface /VCC/.</li><li>UC loads Vonage Business Communicatons ContactPad as a dialer interface /VBC, VBE/.</li></ul> |
+| provider | "cc" / "uc" | <ul><li>CC loads Vonage Call Center ContactPad as a dialer interface /VCC/.</li><li>UC loads Vonage Business Communicatons ContactPad as a dialer interface /VBC, VBE/.</li></ul> |
 | ccDomain (optional) | \[string\] | Use a custom VCC region domain. Well known options are: <ul><li>nam.newvoicemedia.com (default)</li><li>emea.newvoicemedia.com</li><li>apac.newvoicemedia.com</li></ul> |
 
 ### enableClickToDial


### PR DESCRIPTION
Missed a few quotation marks in the last fix. This should be all.